### PR TITLE
Set the "useOptionsAttr" to true on i18next.init config

### DIFF
--- a/src/Bs/Lang.js
+++ b/src/Bs/Lang.js
@@ -71,7 +71,7 @@ Bs.define('Bs.Lang', {
             selectorAttr                : 'data-i18n',
             targetAttr                  : 'i18n-target',
             optionsAttr                 : 'i18n-options',
-            useOptionsAttr              : false,
+            useOptionsAttr              : true,
             parseDefaultValueFromContent: true,
           })
           for (var i = 0, bundle; bundle = _bundles[i]; i++) {


### PR DESCRIPTION
It doesn't change the behavior of "_data-i18n_" but add the possibility to add some options to this translation with "_data-i18n-options_"